### PR TITLE
Fix MSVC warning

### DIFF
--- a/include/gurkenlaeufer/ParserCommon.h
+++ b/include/gurkenlaeufer/ParserCommon.h
@@ -28,15 +28,15 @@ namespace gurkenlaeufer {
         inline std::string toLower(const std::string& input)
         {
             std::string output(input);
-            std::transform(input.begin(), input.end(), output.begin(), ::tolower);
+            std::transform(input.begin(), input.end(), output.begin(), [](unsigned char c){ return std::tolower(c); });
             return output;
         }
 
         //from http://stackoverflow.com/a/17976541
         std::string trim(const std::string& s)
         {
-            auto wsfront = std::find_if_not(s.begin(), s.end(), ::isspace);
-            return std::string(wsfront, std::find_if_not(s.rbegin(), std::string::const_reverse_iterator(wsfront), ::isspace).base());
+            auto wsfront = std::find_if_not(s.begin(), s.end(), [](unsigned char c){ return std::isspace(c); });
+            return std::string(wsfront, std::find_if_not(s.rbegin(), std::string::const_reverse_iterator(wsfront), [](unsigned char c){ return std::isspace(c); }).base());
         }
     }
 }


### PR DESCRIPTION
```
[2021-10-29T06:51:59.929Z] C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\include\algorithm(2892): error C2220: the following warning is treated as an error
[2021-10-29T06:51:59.929Z] C:\c\builds\ExternalLibs\gurkenlaeufer\2017.11.21_17\Applications_common\include\gurkenlaeufer\ParserCommon.h(31): note: see reference to function template instantiation '_OutIt std::transform<std::_String_const_iterator<std::_String_val<std::_Simple_types<_Elem>>>,std::_String_iterator<std::_String_val<std::_Simple_types<_Elem>>>,int(__cdecl *)(int)>(const _InIt,const _InIt,_OutIt,_Fn)' being compiled
[2021-10-29T06:51:59.929Z]         with
[2021-10-29T06:51:59.929Z]         [
[2021-10-29T06:51:59.929Z]             _OutIt=std::_String_iterator<std::_String_val<std::_Simple_types<char>>>,
[2021-10-29T06:51:59.929Z]             _Elem=char,
[2021-10-29T06:51:59.929Z]             _InIt=std::_String_const_iterator<std::_String_val<std::_Simple_types<char>>>,
[2021-10-29T06:51:59.929Z]             _Fn=int (__cdecl *)(int)
[2021-10-29T06:51:59.929Z]         ]
[2021-10-29T06:51:59.929Z] C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\include\algorithm(2892): warning C4244: '=': conversion from 'int' to 'char', possible loss of data
```

See documentation: https://en.cppreference.com/w/cpp/string/byte/tolower
"Like all other functions from <cctype>, the behavior of std::tolower is undefined if the argument's value is neither representable as unsigned char nor equal to EOF. To use these functions safely with plain chars (or signed chars), the argument should first be converted to unsigned char:"
```
char my_tolower(char ch)
{
    return static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
}
```
"Similarly, they should not be directly used with standard algorithms when the iterator's value type is char or signed char. Instead, convert the value to unsigned char first:"
```
std::string str_tolower(std::string s) {
    std::transform(s.begin(), s.end(), s.begin(), 
                // static_cast<int(*)(int)>(std::tolower)         // wrong
                // [](int c){ return std::tolower(c); }           // wrong
                // [](char c){ return std::tolower(c); }          // wrong
                   [](unsigned char c){ return std::tolower(c); } // correct
                  );
    return s;
}
```